### PR TITLE
Added subscriptions support, version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 config.js
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var config = {
   privateKey: yourPrivateKey,
   merchantId: yourMerchantId
 };
-var gateway = require('braintree-js')(config);
+var gateway = require('braintree-node')(config);
 
 gateway.createCustomer(...)
 ```
@@ -158,6 +158,50 @@ app.put('/me', function(req, res) {
     .then(response => {...})
     .catch(error => {...});
 })
+```
+
+###.createSubscription(options)
+
+Wrapper for `.subscription.create`, rejects if planId or nonce is undefined.
+
+```
+app.post('/subscribe', function(req, res) {
+  var planId = req.body.planId;
+  var nonce = req.body.nonce;
+  var options = { planId: planId, paymentMethodNonce: nonce };
+  gateway.createTransaction(options)
+    .then(handleSuccessfulSubscription)
+    .catch(handleFailedSubscription);
+});
+```
+
+###.findSubscription(id)
+
+Finds the customer's subscription with the given id.
+
+```
+app.get('/findSubscription', function(req, res) {
+  var theID = req.body;
+  gateway.findSubscription(theID)
+    .then(function(response) {
+      res.json({planId: response.planId});
+    })
+    .catch(function(error) {
+      res.status(400).json({error: error});
+    });
+})
+```
+
+###.cancelSubscription(id)
+Deletes the customer's subscription with the given id.
+
+```
+app.del('/cancelSubscription', function(req, res) {
+  var theID = req.body;
+  gateway.cancelSubscription(theID)
+    .then(response => {...})
+    .catch(error => {...});
+});
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -285,6 +285,49 @@ module.exports = function(config) {
       });
     });
   }
+
+  /**
+   * @wraps gateway.plans.all
+   * @return {Promise}
+   */
+   gateway.findAllPlans = function() {
+    return new Promise((resolve, reject) => {
+      this.plan.all(function(error, result) {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(result);
+      });
+    });
+   };
+
+
+  /**
+   * @wraps gateway.subscription.create
+   * @param {Object} options, these will be used for creating new subscription
+   * @return {Promise}
+   */
+  gateway.createSubscription = function(options) {
+    return new Promise((resolve, reject) => {
+      if (!options) {
+        return reject(new Error('Plan ID and payment method token is required'));
+      }
+      if (!options.planId) {
+        return reject(new Error('You need to provide plan ID (name)'));
+      }
+      if (!options.paymentMethodToken) {
+        return reject(new Error('Payment method token is required to create subscription'));
+      }
+
+      this.subscription.create(options, function(error, result) {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(result);
+      });
+    });
+  }
+
   function handleEnv(environment) {
     return environment[0].toUpperCase() + environment.slice(1).toLowerCase();
   }

--- a/index.js
+++ b/index.js
@@ -267,6 +267,32 @@ module.exports = function(config) {
   };
 
   /**
+   * @wraps gateway.paymentMethod.create
+   * @param {Object} options, used for creating a payment method
+   * @return {Promise}
+   */
+  gateway.createPaymentMethod = function(options) {
+    return new Promise((resolve, reject) => {
+      if (!options) {
+        return reject(new Error('Customer ID and payment method nonce is required to create payment method'));
+      }
+      if (!options.customerId) {
+        return reject(new Error('Customer ID is required to create payment method'));
+      }
+      if (!options.paymentMethodNonce) {
+        return reject(new Error('Payment method nonce is required to create payment method'));
+      }
+
+      this.paymentMethod.create(options, function(error, result) {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(result);
+      });
+    });
+  }
+
+  /**
    * @param {String} token
    * @return {Promise}
    */
@@ -340,6 +366,26 @@ module.exports = function(config) {
       }
 
       this.subscription.cancel(subscriptionId, function(error, result) {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(result);
+      });
+    });
+  }
+
+  /**
+   * @wraps gateway.subscription.find
+   * @param {String} subscriptionId, subscription ID
+   * @return {Promise}
+   */
+  gateway.findSubscription = function(subscriptionId) {
+    return new Promise((resolve, reject) => {
+      if (!subscriptionId) {
+        return reject(new Error('Subscription ID is required to find subscription'));
+      }
+
+      this.subscription.find(subscriptionId, function(error, result) {
         if (error) {
           return reject(error);
         }

--- a/index.js
+++ b/index.js
@@ -328,6 +328,26 @@ module.exports = function(config) {
     });
   }
 
+  /**
+   * @wraps gateway.subscription.cancel
+   * @param {String} subscriptionId, subscription ID
+   * @return {Promise}
+   */
+  gateway.cancelSubscription = function(subscriptionId) {
+    return new Promise((resolve, reject) => {
+      if (!subscriptionId) {
+        return reject(new Error('Subscription ID is required to cancel subscription'));
+      }
+
+      this.subscription.cancel(subscriptionId, function(error, result) {
+        if (error) {
+          return reject(error);
+        }
+        return resolve(result);
+      });
+    });
+  }
+
   function handleEnv(environment) {
     return environment[0].toUpperCase() + environment.slice(1).toLowerCase();
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-'use strict';
 const braintree = require('braintree');
 /**
  * Module returns an instance of the braintree gateway

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "braintree-node",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "A promise-focused wrapper around the Braintree node.js SDK",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "braintree-node",
   "version": "1.1.0",
   "description": "A promise-focused wrapper around the Braintree node.js SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://www.github.com/varunjayaraman/braintree-node"
+  },
   "main": "index.js",
   "scripts": {
     "test": "NODE_PATH=./ mocha test.js"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "author": "Varun Jayaraman",
   "license": "ISC",
   "dependencies": {
-    "assert": "1.3.0",
-    "braintree": "1.36.0",
+    "braintree": "1.37.1",
+    "chai": "^3.5.0",
     "co": "4.6.0",
     "js-yaml": "3.5.4",
     "lodash": "4.6.1",

--- a/test.js
+++ b/test.js
@@ -46,17 +46,20 @@ describe('braintree wrapper', function() {
     done();
   }).catch(done));
 
-  it('can find a customer', done => co(function*() {
-    try {
-      yield gateway.findCustomer(user.id);
-    } catch (error) {
-      assert.equal(error.type, 'notFoundError');
-    }
-    yield gateway.createCustomer(user);
-    const response = yield gateway.findCustomer(user.id);
-    assert.equal(response.id, 'unique123');
-    done();
-  }).catch(done));
+  it('can find a customer', function(done) {
+    this.timeout(5000);
+    co(function*() {
+      try {
+        yield gateway.findCustomer(user.id);
+      } catch (error) {
+        assert.equal(error.type, 'notFoundError');
+      }
+      yield gateway.createCustomer(user);
+      const response = yield gateway.findCustomer(user.id);
+      assert.equal(response.id, 'unique123');
+      done();
+    }).catch(done);
+  });
 
   it('can update a customer', done => co(function*() {
     yield gateway.createCustomer(user);
@@ -94,19 +97,33 @@ describe('braintree wrapper', function() {
     this.timeout(5000);
     co(function*() {
       const response = yield gateway.createTransaction({
-        amount: 15,
+        amount: 25,
         paymentMethodNonce: fakeData.nonces.valid.nonce
       });
       assert.ok(response.success);
-      assert.equal(response.transaction.amount, '15.00');
+      assert.equal(response.transaction.amount, '25.00');
       const id = response.transaction.id;
 
-      const cloneResponse = yield gateway.cloneTransaction(id, 35);
+      const cloneResponse = yield gateway.cloneTransaction(id, '35.00');
       assert.ok(cloneResponse.success);
       assert.equal(cloneResponse.transaction.amount, '35.00');
       done();
     }).catch(done);
   });
+
+  it('can create a payment method', done => co(function*() {
+    const newCustomer = yield gateway.createCustomer(user);
+    assert.ok(newCustomer.success);
+    assert.equal(newCustomer.customer.id, 'unique123');
+
+    const response = yield gateway.createPaymentMethod({
+      customerId: newCustomer.customer.id,
+      paymentMethodNonce: fakeData.nonces.valid.nonce
+    });
+    assert.ok(response.success);
+    expect(response.paymentMethod).to.have.property('token');
+    done();
+  }).catch(done));
 
   it('should have atleast one plan ready for subscriptions', done => co(function*() {
     const response = yield gateway.findAllPlans();
@@ -140,7 +157,37 @@ describe('braintree wrapper', function() {
     }).catch(done);
   });
 
-  it('cancels a subscription', function(done) {
+  it('can find a subscription', function(done) {
+    this.timeout(8000);
+    co(function*() {
+      const getPlans = yield gateway.findAllPlans();
+      const planId = getPlans.plans[0].id;
+
+      const newUser = yield gateway.createCustomer({
+        id: user.id,
+        paymentMethodNonce: fakeData.nonces.valid.nonce
+      });
+      assert.ok(newUser.success);
+      assert.equal(newUser.customer.id, 'unique123');
+      expect(newUser.customer.paymentMethods[0]).to.have.property('token');
+      const token = newUser.customer.paymentMethods[0].token;
+
+      const newSubscription = yield gateway.createSubscription({
+        planId: planId,
+        paymentMethodToken: token
+      });
+      assert.ok(newSubscription.success);
+      assert.equal(newSubscription.subscription.status, 'Active');
+      const subscriptionId = newSubscription.subscription.id;
+
+      const response = yield gateway.findSubscription(subscriptionId);
+      assert.equal(response.id, subscriptionId);
+      assert.equal(response.status, 'Active');
+      done();
+    }).catch(done);
+  });
+
+  it('can cancel a subscription', function(done) {
     this.timeout(5000);
     co(function*() {
       const getPlans = yield gateway.findAllPlans();
@@ -169,4 +216,5 @@ describe('braintree wrapper', function() {
       done();
     }).catch(done);
   });
+
 });


### PR DESCRIPTION
- added `createSubscription`, `cancelSubscription`, `findSubscription` helpers
- added `createPaymentMethod` helper (if somebody would need it to use separately like that instead creating it simultaneously with `createCustomer`)
- added `findAllPlans` helper for accessing the subscription plans with Braintree API (useful for subscriptions) https://developers.braintreepayments.com/reference/request/plan/all/node
- added Chai.js library for testing (`assert` and `expect`)
- added tests, fixed failing tests with adding higher timeouts here and there
- updated readme, fixed typo
- added git repository field into package.json
- bumped version to 1.1.0